### PR TITLE
Fix Spells

### DIFF
--- a/portals.lua
+++ b/portals.lua
@@ -676,7 +676,9 @@ local function ShowMenuEntries(category)
     if methods[category] then
         for _, menuEntry in pairsByKeys(methods[category]) do
             if menuEntry.itemType == "spell" then
-                if menuEntry.secure and GetSpellCooldown(menuEntry.itemName) == 0 then
+                local spellCooldown
+                if isCataclysmClassic then spellCooldown = GetSpellCooldown(menuEntry.itemName) else spellCooldown = GetSpellCooldown(menuEntry.itemName).startTime end
+                if menuEntry.secure and spellCooldown == 0 then
                     dewdrop:AddLine(
                         'textHeight', PortalsDB.fontSize,
                         'text', menuEntry.itemName,


### PR DESCRIPTION
Unfortunately, this code will not work on Retail:

`if menuEntry.secure and GetSpellCooldown(menuEntry.itemName) == 0 then`

The reason for this is that `C_Spell.GetSpellCooldown` returns a table, so as long as the spell itself is valid then the value returned is never going to be 0 (nil).   In other words, the addon was interpreting every valid spell as being on cooldown.

The way I fixed this was what I thought would be the least amount of changes, utilizing the boolean variable that you already had established:

```
local spellCooldown
if isCataclysmClassic then spellCooldown = GetSpellCooldown(menuEntry.itemName) else spellCooldown = GetSpellCooldown(menuEntry.itemName).startTime end
if menuEntry.secure and spellCooldown == 0 then
```

