### PR TITLE
Add Engineering Item Cooldowns (but only when cooldown is active)

### DIFF
--- a/portals.lua
+++ b/portals.lua
@@ -804,13 +804,13 @@ local function GetItemCooldowns()
         if GetItemCount(items[i]) > 0 or (PlayerHasToy(items[i]) and C_ToyBox.IsToyUsable(items[i])) then
             startTime, duration = GetItemCooldown(items[i])
             cooldown = duration - (GetTime() - startTime)
-            if cooldown <= 0 then
-                cooldown = L['READY']
-            else
-                cooldown = SecondsToTime(cooldown)
-            end
             local name = GetItemInfo(items[i]) or select(2, C_ToyBox.GetToyInfo(items[i]))
             if name then
+                if cooldown <= 0 then
+                    cooldown = L['READY']
+                else
+                    cooldown = SecondsToTime(cooldown)
+                end
                 cooldowns[name] = cooldown
             end
         end
@@ -821,9 +821,9 @@ local function GetItemCooldowns()
             startTime, duration = GetItemCooldown(engineeringItems[i])
             cooldown = duration - (GetTime() - startTime)
             if cooldown > 0 then
-                cooldown = SecondsToTime(cooldown)
                 local name = GetItemInfo(engineeringItems[i]) or select(2, C_ToyBox.GetToyInfo(engineeringItems[i]))
                 if name then
+                    cooldown = SecondsToTime(cooldown)
                     cooldowns[name] = cooldown
                 end
             end

--- a/portals.lua
+++ b/portals.lua
@@ -796,6 +796,9 @@ end
 
 local function GetItemCooldowns()
     local cooldown, cooldowns, hours, mins, secs
+    if cooldowns == nil then
+        cooldowns = {}
+    end
 
     for i = 1, #items do
         if GetItemCount(items[i]) > 0 or (PlayerHasToy(items[i]) and C_ToyBox.IsToyUsable(items[i])) then
@@ -806,18 +809,27 @@ local function GetItemCooldowns()
             else
                 cooldown = SecondsToTime(cooldown)
             end
-
-            if cooldowns == nil then
-                cooldowns = {}
-            end
-
             local name = GetItemInfo(items[i]) or select(2, C_ToyBox.GetToyInfo(items[i]))
-
             if name then
                 cooldowns[name] = cooldown
             end
         end
     end
+
+    for i = 1, #engineeringItems do
+        if GetItemCount(engineeringItems[i]) > 0 or (PlayerHasToy(engineeringItems[i]) and C_ToyBox.IsToyUsable(engineeringItems[i])) then
+            startTime, duration = GetItemCooldown(engineeringItems[i])
+            cooldown = duration - (GetTime() - startTime)
+            if cooldown > 0 then
+                cooldown = SecondsToTime(cooldown)
+                local name = GetItemInfo(engineeringItems[i]) or select(2, C_ToyBox.GetToyInfo(engineeringItems[i]))
+                if name then
+                    cooldowns[name] = cooldown
+                end
+            end
+        end
+    end
+
     return cooldowns
 end
 


### PR DESCRIPTION
This pull request modifies `GetItemCooldowns()` to include Engineering Items (but, only display if the item has an active cooldown.)    In other words, with this modification, wormhole generator cooldowns will show when hovering over broker_portals, but only if there is currently a cooldown for that item.

For example:
![1](https://github.com/user-attachments/assets/a2f14208-e3c6-4d2d-96dc-469fd4898754)

and
![2](https://github.com/user-attachments/assets/4ec02aff-ada1-44ff-9301-913a6a16d632)
