### PR TITLE
WoW 12.0.0 Compatibility: LibDewdrop-3.0 MenuUtil support

### DIFF
--- a/Broker_Portals.toc
+++ b/Broker_Portals.toc
@@ -1,4 +1,4 @@
-## Interface: 50500, 40402, 110105, 110107, 11507, 20505
+## Interface: 20505, 50500, 40402, 120000, 120001
 ## Title: Broker - |cffffffffPortals|r
 ## Notes: Provides access to all Portal and Teleport spells on right click of one button.
 ## Author: CrazyBenny of Stormrage-EU and Bissental on FlameGor-EU

--- a/portals.lua
+++ b/portals.lua
@@ -425,6 +425,11 @@ end
 frame:SetScript('OnEvent', function(self, event, ...) if self[event] then return self[event](self, event, ...) end end)
 frame:RegisterEvent('PLAYER_LOGIN')
 
+-- Helper function to extract item ID from item link
+local function GetItemIDFromLink(itemlink)
+    return tonumber(tostring(itemlink):match("item:(%d+)"))
+end
+
 local function BPToggleMinimap()
     local hide = not PortalsDB.minimap.hide
     PortalsDB.minimap.hide = hide
@@ -606,10 +611,6 @@ end
 local function tconcat(t1, t2)
     for i = 1, #t2 do t1[#t1 + 1] = t2[i] end
     return t1
-end
-
-local function GetItemIDFromLink(itemlink)
-    return tonumber(tostring(itemlink):match("item:(%d+)"))
 end
 
 -- returns true, if player has item with given ID in inventory or bags and it's not on cooldown
@@ -968,9 +969,7 @@ local function ShowMenuEntries(category, sortTable)
                     'textB',        menuEntry.itemRGB.b,
                     'secure',       menuEntry.secure,
                     'icon',         tostring(menuEntry.itemIcon),
-                    'func',         function()
-                        UpdateIcon(menuEntry.itemIcon)
-                    end,
+                    'func',         function() UpdateIcon(menuEntry.itemIcon) end,
                     'closeWhenClicked', true)
             end
         end
@@ -1213,7 +1212,13 @@ end
 
 function obj.OnClick(self, button)
     GameTooltip:Hide()
-    if button == 'RightButton' then dewdrop:Open(self, 'children', function(level, value) UpdateMenu(level, value) end) end
+    if button == 'LeftButton' or button == 'RightButton' then
+        if dewdrop:IsOpen(self) then
+            dewdrop:Close()
+        else
+            dewdrop:Open(self, 'children', function(level, value) UpdateMenu(level, value) end)
+        end
+    end
 end
 
 function obj.OnLeave() GameTooltip:Hide() end


### PR DESCRIPTION
## Summary

- Added `120000` and `120001` to TOC Interface versions for WoW 12.0.0 (Midnight).  Also removed old 11.x versions that are no longer being used by anyone.
- Updated LibDewdrop-3.0 to support both the legacy UIDropDownMenu system and the new MenuUtil API
- Added left-click support and toggle behavior for the menu

## LibDewdrop-3.0 Changes

WoW 12.0.0 replaced the UIDropDownMenu system with MenuUtil. This pull request updates LibDewdrop-3.0 so the library works on both old and new clients. In other words, those playing on classic servers should notice no difference whatsoever.

**How it works:**
- At load time, the library checks if `MenuUtil` exists
- If yes (12.0.0+): Uses the new Menu API with proper anchor positioning
- If no (older clients): Uses the original UIDropDownMenu implementation

**Key technical changes for 12.0.0:**
- Uses `Menu.GetManager():OpenMenu()` with `CreateAnchor()` for correct menu positioning (`MenuUtil.CreateContextMenu` always anchors to cursor)
- Implements secure button overlay for spells/items/toys (MenuUtil buttons are not secure)
- Secure overlay includes `OnEnter`/`OnLeave` handlers to display tooltips
- Uses `HookOnEnter`/`HookOnLeave` instead of `SetOnEnter`/`SetOnLeave` (`SetTooltip` overwrites `SetOnEnter`)
- Adds `GetMouseFocus` compatibility wrapper (`GetMouseFoci()` returns a table in 12.0.0)
- Includes flickering prevention when mouse moves between menu button and secure overlay
- Uses custom Font object with `SetFontObject()` for font sizing (`SetFont()` disallowed on compositor font strings)
- Scales button height with font size to prevent text overlap

**Preserved functionality:**
- Titles, dividers, checkboxes, and submenus
- Icons and tooltips
- Secure action buttons for casting spells and using items/toys
- Font size setting works via custom Font object (row height scales proportionally)
- Scroll list size setting

## portals.lua Changes

- Menu now opens on both left-click and right-click
- Clicking toggles the menu open/closed

## Visual Styling Note

The new MenuUtil-based menus use Blizzard's standard context menu appearance rather than the original LibDewdrop dark window style. MenuUtil controls its own rendering and doesn't expose styling options. The current approach prioritizes maintainability and forward-compatibility with Blizzard's menu system.

> **Note:** Some advanced LibDewdrop features (sliders, edit boxes, color swatches) have stub implementations in the new MenuUtil path since Broker_Portals doesn't use them. These can be fully implemented if needed in the future.

## Testing

- [x] Addon loads without errors on 12.0.0 client
- [x] Portal/teleport menus display correctly
- [x] Secure buttons function for casting spells and using items/toys
- [x] Menu positioning and toggle behavior work correctly